### PR TITLE
meta: add efiop to maintainers

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -36,3 +36,5 @@ jobs:
     displayName: Run docker build
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+      FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+      STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @FernandezMathieu @ericdill @mariusvniekerk @parente
+* @FernandezMathieu @efiop @ericdill @mariusvniekerk @parente

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -43,9 +43,10 @@ else
     conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
     if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-        upload_package  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+        upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
     fi
 fi
 

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -77,6 +77,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e BUILD_WITH_CONDA_DEBUG \
            -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
+           -e FEEDSTOCK_TOKEN \
+           -e STAGING_BINSTAR_TOKEN \
            $DOCKER_IMAGE \
            bash \
            /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Feedstock Maintainers
 =====================
 
 * [@FernandezMathieu](https://github.com/FernandezMathieu/)
+* [@efiop](https://github.com/efiop/)
 * [@ericdill](https://github.com/ericdill/)
 * [@mariusvniekerk](https://github.com/mariusvniekerk/)
 * [@parente](https://github.com/parente/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,3 +54,4 @@ extra:
     - ericdill
     - parente
     - FernandezMathieu
+    - efiop


### PR DESCRIPTION
We actively use this package in dvc https://github.com/conda-forge/dvc-feedstock and I will be able to help out with any maintenance to keep this package in-check.

From discussion https://github.com/conda-forge/python-hdfs-feedstock/pull/24

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
